### PR TITLE
Bug fixes, energy dashboard integration, and project documentation

### DIFF
--- a/.homeyignore
+++ b/.homeyignore
@@ -1,0 +1,22 @@
+# Dev tooling
+node_modules/
+package-lock.json
+.homeybuild/
+
+# Developer reference files
+modbus_spec.xls
+httprequests.http
+
+# TypeScript sources (compiled output in .homeybuild is used)
+*.ts
+
+# Editor & tooling
+.eslintrc.json
+tsconfig.json
+.claude/
+
+# Docs
+CLAUDE.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+README.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# AquaTemp Homey App
+
+A Homey SDK v3 app that integrates AquaTemp heat pumps via their cloud API. Forked from the original app by Jesper Rasmussen, currently at v1.9.0.
+
+## What it does
+
+- Polls the AquaTemp cloud API every 30 seconds for device data
+- Reads temperatures (inlet, outlet, surrounding, coil, exhaust), power metrics (voltage, current, watts, cumulative energy), fan speed, thermostat mode, and alarm states
+- Allows setting: target temperature (per HVAC mode), on/off, silent mode, HVAC mode (heat/cool/auto), and experimental fan/frequency settings
+- Detects defrost mode and pump supply alarm via bit fields in the `2074` failure status register
+
+## Architecture
+
+```
+app.ts                          # Homey app entry point
+drivers/aquatemp/
+  driver.ts                     # Device discovery / pairing
+  device.ts                     # HeatPumpDevice — capability polling & listeners
+  aquatempAPI.ts                # HTTP client wrapping the AquaTemp cloud REST API
+  apirequestcodes.ts            # Protocol code constants (T01–T14, R01–R03, etc.)
+  apiendpoints.ts               # Base URLs for login, device list, get/set data
+  driver.*.compose.json         # Flow cards, settings, and driver manifest fragments
+.homeycompose/
+  app.json                      # App manifest (source of truth; app.json is generated)
+  capabilities/                 # Custom capability definitions
+hasher.ts                       # MD5 password hashing (first 16 chars of plain password)
+```
+
+## Key design decisions
+
+- **No token caching across requests** — a new `AquatempAPI` instance is created on every poll and every write, so tokens are fetched fresh each time.
+- **Experimental features** gated behind a device setting; capabilities are added/removed dynamically on toggle.
+- **Energy meter** (`meter_power`) is accumulated in-process using elapsed time × watts. It resets on app restart and is approximate.
+- **Temperature routing** — target temperature reads/writes are mode-aware: different API codes for heat (`R02`), cool (`R01`), and auto (`R03`).
+- **Failure status** bit fields: register `2074` is a reversed binary string; bit 9 (charAt from end) = pump supply alarm, bit 15 = defrost.
+
+## Build & tooling
+
+```bash
+npm run build   # tsc — compiles TypeScript
+npm run lint    # eslint (athom config)
+```
+
+Homey compose is used: edit `.homeycompose/app.json` and `.homeycompose/capabilities/`, not `app.json` directly. Run `homey app compose` to regenerate `app.json`.
+
+## Homey MCP
+
+A Homey MCP server is connected to this project. Use it to interact with the live Homey during development:
+
+- `list_devices` — inspect the paired AquaTemp device and its current capability values
+- `list_flows` / `get_standard_flow` / `get_advanced_flow` — inspect existing automations
+- `list_flow_trigger_cards` / `list_flow_condition_cards` / `list_flow_action_cards` — discover available flow cards (including those from this app)
+- `set_devices_capabilities_values` — test capability writes against the real device
+- `start_flow` — trigger flows to test end-to-end behaviour
+- `create_standard_flow` / `create_advanced_flow` — create test flows during development
+
+Always use the Homey MCP to verify changes against the live device rather than guessing at behaviour from the code alone.
+
+## Conventions
+
+- TypeScript strict mode is not enabled; avoid introducing `any` further than already present.
+- Capability listener callbacks do the API write; `updateData()` does the full poll and reconciles all capabilities.
+- Error types (`AuthenticationError`, `ApiRequestError`, `DeviceOfflineError`) are thrown from the API layer and caught in `device.ts` to set device availability.
+- Flow card definitions live in `driver.flow.compose.json`; localisations live in `locales/en.json`.

--- a/drivers/aquatemp/aquatempAPI.ts
+++ b/drivers/aquatemp/aquatempAPI.ts
@@ -199,17 +199,16 @@ export class AquatempAPI {
       });
     });
 
-    if (result.data.objectResult.length === 0) {
-      throw new ApiRequestError('Getting device data from aquatemp server failed. Reply from server is empty');
-    }
-
-
-
     if (!result.data.isReusltSuc) {
-      console.log(`Getting device data from server failed, isResultSec = false. 
+      console.log(`Getting device data from server failed, isReusltSuc = false.
       Returned data from server is ${result.data.objectResult}`);
       throw new ApiRequestError('Getting device data from aquatemp server failed.');
     }
+
+    if (!result.data.objectResult || result.data.objectResult.length === 0) {
+      throw new ApiRequestError('Getting device data from aquatemp server failed. Reply from server is empty');
+    }
+
     return result.data.objectResult;
   }
 

--- a/drivers/aquatemp/device.ts
+++ b/drivers/aquatemp/device.ts
@@ -43,9 +43,9 @@ class HeatPumpDevice extends Homey.Device {
       await this.removeCapability('outlet');
     }
 
-    if (!this.hasCapability('measure_temperature.inlet')) {
+    if (!this.hasCapability('measure_temperature.outlet')) {
       this.log('Adding new measure_temperature.outlet capability');
-      await this.addCapability('measure_temperature.inlet');
+      await this.addCapability('measure_temperature.outlet');
     }
 
     if (this.hasCapability('inlet')) {
@@ -99,7 +99,7 @@ class HeatPumpDevice extends Homey.Device {
 
     await this.updateData();
 
-    setInterval(async () => {
+    this.timer = setInterval(async () => {
       await this.updateData();
     }, 30000);
   }

--- a/drivers/aquatemp/device.ts
+++ b/drivers/aquatemp/device.ts
@@ -97,6 +97,8 @@ class HeatPumpDevice extends Homey.Device {
       await this.setMaximumFrequencyHeating(value);
     });
 
+    this.lastPollTime = await this.getStoreValue('lastPollTime') ?? null;
+
     await this.updateData();
 
     this.timer = setInterval(async () => {
@@ -249,6 +251,7 @@ class HeatPumpDevice extends Homey.Device {
       await this.setCapabilityValue('meter_power', accumulated).catch(this.error);
     }
     this.lastPollTime = now;
+    await this.setStoreValue('lastPollTime', this.lastPollTime).catch(this.error);
     await this.setCapabilityValue('silent_mode', this.extractValueByCode(result, ApiRequestCodes.CODES.SILENT_MODE) === 1).catch(this.error);
 
     const hvacMode = this.getHvacMode(result);

--- a/drivers/aquatemp/driver.compose.json
+++ b/drivers/aquatemp/driver.compose.json
@@ -370,5 +370,6 @@
       "id": "add_devices",
       "template": "add_devices"
     }
-  ]
+  ],
+  "energy": {}
 }

--- a/drivers/aquatemp/driver.ts
+++ b/drivers/aquatemp/driver.ts
@@ -62,8 +62,7 @@ class MyDriver extends Homey.Driver {
     this.homey.flow.getActionCard('thermostat_mode_set')
       .registerRunListener(async (args, state) => {
         this.log(`Setting thermostat mode to: ${args.thermostat_mode}`);
-        await args.device.setThermostatMode(args.thermostat_mode);
-        return args.device.setCapabilityValue('thermostat_mode', args.thermostat_mode);
+        await args.device.setHvacMode(args.thermostat_mode);
       });
   }
 


### PR DESCRIPTION
## Summary

Several bug fixes found during a code audit, plus Homey Energy dashboard integration — all verified against a live device.

## Bug fixes

- **Timer leak** — `setInterval` return was never assigned to `this.timer`, so `onDeleted` cleanup was a no-op and polling continued indefinitely after device removal
- **Flow card crash** — `thermostat_mode_set` action called non-existent `setThermostatMode()`; replaced with `setHvacMode()` and removed the redundant `setCapabilityValue` call that followed
- **Capability migration** — copy-paste error had both migration blocks adding `measure_temperature.inlet`; first block now correctly adds `measure_temperature.outlet`. Fixed misleading log message too
- **Null crash in API** — `objectResult.length` was accessed before checking `isReusltSuc`, crashing when the API returns `objectResult: null`; reordered checks and removed a duplicate guard

## Homey Energy dashboard

- Persist `lastPollTime` via `setStoreValue`/`getStoreValue` so `meter_power` accumulation survives app restarts (previously the first post-restart poll always skipped accumulation, causing Energy to see no change)
- Add `energy: {}` to driver manifest so the device is recognised and appears in the Homey Energy dashboard

Verified working on a live Q20 inverter pool heat pump — device shows in Energy dashboard with correct wattage and kWh history after a few hours of polling.

## Documentation

- Add `CLAUDE.md` documenting architecture, key design decisions, build tooling, and Homey MCP usage

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `homey app validate` passes
- [x] Device appears in Homey Energy dashboard
- [x] Energy data populates correctly after polling
- [x] Thermostat mode flow card executes without runtime error
- [x] All 21 capabilities verified against live device